### PR TITLE
Potential fix for code scanning alert no. 1: Useless regular-expression character escape

### DIFF
--- a/src/pages/api/contact.ts
+++ b/src/pages/api/contact.ts
@@ -28,7 +28,7 @@ export const POST: APIRoute = async ({ request }) => {
     // Basic server-side validation
     const errors: Record<string, string> = {};
     const emailRegex = new RegExp(
-      `^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$`
+      `^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$`
     );
 
     if (!name) errors.name = "Name is required";


### PR DESCRIPTION
Potential fix for [https://github.com/The-Best-Codes/bestcodes.dev/security/code-scanning/1](https://github.com/The-Best-Codes/bestcodes.dev/security/code-scanning/1)

To fix the problem, we need to ensure that the dot character in the regular expression is properly escaped. This can be done by adding an extra backslash in the string literal to ensure that the dot is interpreted correctly in the regular expression.

- In general terms, we need to replace `\.` with `\\.` in the string literal to ensure that the dot is matched literally in the regular expression.
- Specifically, we need to update the regular expression on line 31 in the file `src/pages/api/contact.ts`.
- No additional methods, imports, or definitions are needed to implement this change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
