### PR TITLE
Potential fix for code scanning alert no. 20: Uncontrolled data used in path expression

### DIFF
--- a/lib/getImageDynamic.ts
+++ b/lib/getImageDynamic.ts
@@ -1,6 +1,7 @@
 "use server";
 import fs from "fs";
 import sharp from "sharp";
+import path from "path";
 
 export default async function getDynamicImageAsStatic(
   imageUrl: string,
@@ -32,7 +33,20 @@ export async function getImageBlurURL(
   blurHeight?: number,
   blurQuality?: number,
 ) {
-  const imageBuffer = await fs.promises.readFile(imagePath);
+  // Define the root directory for images
+  const ROOT = "/your/safe/image/root"; // TODO: Set this to your actual image directory
+  // Resolve and validate the image path
+  const resolvedPath = path.resolve(ROOT, imagePath);
+  let realPath: string;
+  try {
+    realPath = await fs.promises.realpath(resolvedPath);
+  } catch (err) {
+    throw new Error("Invalid image path");
+  }
+  if (!realPath.startsWith(ROOT)) {
+    throw new Error("Access to the requested file is forbidden");
+  }
+  const imageBuffer = await fs.promises.readFile(realPath);
   const { width, height } = await sharp(imageBuffer).metadata();
   const blurWidthResize = width ? Math.round(width / (blurQuality || 15)) : 0;
   const blurHeightResize = height


### PR DESCRIPTION
Potential fix for [https://github.com/The-Best-Codes/bestcodes.dev/security/code-scanning/20](https://github.com/The-Best-Codes/bestcodes.dev/security/code-scanning/20)

To fix this issue, we need to ensure that the `imagePath` parameter in `getImageBlurURL` cannot be used to access files outside of a designated safe directory (a "root" directory). The best way to do this is to:

1. Define a root directory (e.g., `const ROOT = "/some/safe/root"`).
2. When `imagePath` is provided, resolve it relative to the root directory using `path.resolve`.
3. Use `fs.realpathSync` (or `await fs.promises.realpath`) to resolve any symlinks and normalize the path.
4. Check that the resulting path starts with the root directory path. If it does not, throw an error or return an appropriate response.
5. Only then, proceed to read the file.

This approach prevents path traversal and ensures that only files within the intended directory can be accessed.

**Required changes:**
- Import the `path` module.
- Define a constant for the root directory.
- Update the code in `getImageBlurURL` to resolve and validate the path before reading the file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
